### PR TITLE
Fix toolbar tab error

### DIFF
--- a/source/class/qxl/widgetbrowser/pages/ToolBar.js
+++ b/source/class/qxl/widgetbrowser/pages/ToolBar.js
@@ -42,9 +42,7 @@
  * toolbar.SplitButton
  * toolbar.ToolBar
  *
- * @asset(qx/icon/${qx.icontheme}/16/actions/*)
- * @asset(qx/icon/${qx.icontheme}/16/apps/utilities-help.png)
- * @asset(qx/icon/${qx.icontheme}/22/apps/preferences-users.png)
+ * @asset(qx/iconfont/MaterialIcons/*)
  *
  */
 


### PR DESCRIPTION
Fix #4. I removed assets for old icons and add asset for MaterialIcons. It loads all font icons from qooxdoo framework and obviously it is not optimal way. Maybe to include some files of MaterialIcons and add them into resource folder and Manifest file? The error is gone and toolbar tab works. If consider this solution it is ok I think. I did like it is done in testtapper project.