### PR TITLE
IndigoDark Theme

### DIFF
--- a/Manifest.json
+++ b/Manifest.json
@@ -21,9 +21,12 @@
       "name": "widgetbrowser",
       "title": "WidgetBrowser",
       "include": [
+        "qx.theme.IndigoDark",
         "qx.theme.Modern",
         "qx.theme.Simple",
         "qx.theme.Classic",
+        "qx.theme.TangibleLight",
+        "qx.theme.TangibleDark",
         "qxl.widgetbrowser.pages.Tree",
         "qxl.widgetbrowser.pages.List",
         "qxl.widgetbrowser.pages.Table",
@@ -40,6 +43,6 @@
     }
   },
   "requires": {
-    "@qooxdoo/framework": "^7.0.0"
+    "@qooxdoo/framework": "^7.5.0"
   }
 }

--- a/compile.json
+++ b/compile.json
@@ -14,6 +14,7 @@
          "title": "WidgetBrowser",
          "include": [
             "qx.theme.Indigo",
+            "qx.theme.IndigoDark",
             "qx.theme.Modern",
             "qx.theme.Simple",
             "qx.theme.Classic",
@@ -34,7 +35,6 @@
          ]
       }
    ],
-   /** Targets */
    "targets": [
       {
          "type": "source",


### PR DESCRIPTION
- Added IndigoDark theme in `compile.json` and `Manifest.json`
- Removed redundent comment
- Increased compatible dependency - qooxdoo framework
- Added tangible themes in Manifest.json

I noticed when I install this package as dependency and run: `qx serve -S`. I don't see tangible themes. It is proly bc there are no in `Manifest.json`. I doubt about this solution. If I am wrong let me know.