### PR TITLE
Select theme button fixes

### DIFF
--- a/source/class/qxl/widgetbrowser/view/Header.js
+++ b/source/class/qxl/widgetbrowser/view/Header.js
@@ -65,7 +65,7 @@ qx.Class.define("qxl.widgetbrowser.view.Header", {
       }
     }
     select.setFont("default");
-    select.setTextColor("black");
+    select.setTextColor(null);
     select.setWidth(250);
     select.addListener("changeSelection", function (evt) {
       var selected = evt.getData()[0].getUserData("value");
@@ -73,6 +73,7 @@ qx.Class.define("qxl.widgetbrowser.view.Header", {
       if (theme) {
         qx.theme.manager.Meta.getInstance().setTheme(theme);
       }
+      this.close();
     });
 
     // Set current theme


### PR DESCRIPTION
Fixed #3.  Also some strange behaviour during changing theme in select menu sometimes it closes sometimes doesn't. Now after selecting them in menu it is always closed.

Have the next bug: If I select indigo theme then classic for example and back to indigo everything is fine but if I select 1) `Indigo` than `IndigoDark` or  2) `TangiableLight` than `TangiableDark` the font of select theme button wont be changed. I've checked out what these two cases have in common and found that in both cases the text font class is the same. 